### PR TITLE
Fixes to README (spelling and gttsmap_mp)

### DIFF
--- a/README
+++ b/README
@@ -7,14 +7,14 @@ and was reviewed by the Fermi Users' Group.  The LAT Multi-Processor
 Scripts are a set of python scripts to facilitate the analysis of LAT
 data.  This package depends on the Fermi Science Tools.
 
-The current tools avaialble are
+The current tools available are
 
     * gtdiffrsp_mp.py
     * gtexpmap_mp.py
     * gtltcube_mp.py
     * gttsmap_mp.py (Unbinned Only)
 
-To recieve information on program execution for a specific script execute:
+To receive information on program execution for a specific script execute:
 
    > python <gtapp>_mp.py -h
 
@@ -22,7 +22,7 @@ See below for details on each tool.
 
 * gtdiffrsp_mp.py *
 
-  Submits the gtdiffrsp program as seperate threads via python and
+  Submits the gtdiffrsp program as separate threads via python and
   joins up the resulting temporary files at the end resulting in a
   single file. This greatly reduces the running time. For more details
   on gtdiffrsp see the gtdiffrsp help file.
@@ -47,7 +47,7 @@ See below for details on each tool.
 
   example: 
   This computes the diffuse response for the data in the file
-  '3C279_events.fits' using 4 seperate threads using the spacecraft
+  '3C279_events.fits' using 4 separate threads using the spacecraft
   file 'SC.fits', the model file '3C279_model.xml' and the P7SOURCE_V6
   instrument response functions.  It saves the output in
   '3C279_events_diffrsp.fits'
@@ -57,7 +57,7 @@ See below for details on each tool.
 
 * gtexpmap_mp.py *
 
-  Submits the gtexpmap program as sperate threads via python and joins
+  Submits the gtexpmap program as operate threads via python and joins
   up the resulting temporary exposure maps at the end resulting in a
   single exposure map for the input event file. This greatly reduces the
   running time. For more details on gtexpmap see the gtexpmap help
@@ -106,7 +106,7 @@ See below for details on each tool.
 
 * gtltcube_mp.py *
 
-  Submits the gtltcube program as sperate threads via python and joins
+  Submits the gtltcube program as operate threads via python and joins
   up the resulting temporary exposure cubes at the end resulting in a
   single exposure cube for the input event file. This greatly reduces
   the running time. For more details on gtltcube see the gtltcube help
@@ -139,16 +139,16 @@ See below for details on each tool.
 
 * gttsmap_mp.py *
 
-  Generates a TS Map by running seperate pixels on seperate
+  Generates a TS Map by running separate pixels on separate
   threads. It creates a template counts map to determine the location
   of the pixels and the calculates the TS of a test source at each
   pixel on that map. It then merges the results at the end. The map is
-  divided into seperate regions (called 000,001,002...) depending on
+  divided into separate regions (called 000,001,002...) depending on
   the number of jobs the user requests. It creates subdirectories for
   each region and operates on them within the subdirectory.  For more
   details on the parameters see the gttsmap help file. NOTE: ONLY DOES
   AN UNBINNED ANALYSIS. NOTE2: Any files referenced in the model XML
-  file must be referenced by abosolute and not relative directories
+  file must be referenced by absolute and not relative directories
   (ie. not ./ or ../)"
 
   usage: gttsmap_mp.py [-h] [--savetmp SAVETMP]

--- a/README
+++ b/README
@@ -152,9 +152,9 @@ See below for details on each tool.
   (ie. not ./ or ../)"
 
   usage: gttsmap_mp.py [-h] [--savetmp SAVETMP]
-  	               nxpix nypix jobs evfile scfile expmap expcube srcmdl IRFS
+  	               nxpix nypix jobs evfile scfile expcube srcmdl IRFS
                        optimizer ftol toltype binsz coordsys xref yref proj
-                       outfile
+                       outfile UNBINNED expmap
 
 		       	  
   positional arguments:
@@ -165,8 +165,6 @@ See below for details on each tool.
   jobs               The number of concurrent jobs.
   evfile             Input event file. See gttsmap help for more information.
   scfile             The spacecraft data file. See gttsmap help for more
-                     information.
-  expmap             Input exposure map. See gttsmap help for more
                      information.
   expcube            Input livetime cube. See gttsmap help for more
                      information.
@@ -190,6 +188,9 @@ See below for details on each tool.
   proj               Coordinate projection. See gttsmap help for more
                      information.
   outfile            Output file name.
+  analysis           UNBINNED. Only unbinned analysis supported.
+  expmap             Input exposure map. See gttsmap help for more
+                     information.
 
   optional arguments:
   -h, --help         show this help message and exit
@@ -205,6 +206,7 @@ See below for details on each tool.
   absolute tolerance of 1e-5.  The map is centered on 193.98,-5.82 and
   is created using the STG celestial coordinate system.
 
-  > python gttsmap_mp3.py 10 10 6 3C279_filtered_gti.fits SC.fits
-    3C279_expmap.fits 3C279_ltcube.fits 3C279_model.xml P7SOURCE_V6
-    MINUIT 1e-05 1 0.5 CEL 193.98 -5.82 STG 3C279_tsmap.fits
+  > python gttsmap_mp.py 10 10 6 3C279_filtered_gti.fits SC.fits
+    3C279_ltcube.fits 3C279_model.xml P7SOURCE_V6
+    MINUIT 1e-05 1 0.5 CEL 193.98 -5.82 STG 3C279_tsmap.fits UNBINNED
+    3C279_expmap.fits


### PR DESCRIPTION
Hi Jeremy,

I fixed a few spelling mistakes in the README and also added some suggestions in order to get gttsmap_mp running. The way the instructions were written, I could not get gttsmap_mp working (it complained about too few arguments). I figured out that was the correct way of placing the arguments by inspecting the source code.

Cheers,
Rodrigo
